### PR TITLE
Mirror of zephyrproject-rtos net-tools#46

### DIFF
--- a/zeth0-gptp.conf
+++ b/zeth0-gptp.conf
@@ -1,0 +1,6 @@
+# First gPTP interface
+INTERFACE="$1"
+HWADDR="00:00:5e:00:53:11"
+
+ip link set dev $INTERFACE up
+ip link set dev $INTERFACE address $HWADDR

--- a/zeth1-gptp.conf
+++ b/zeth1-gptp.conf
@@ -1,0 +1,6 @@
+# Second gPTP interface
+INTERFACE="$1"
+HWADDR="00:00:5e:00:53:22"
+
+ip link set dev $INTERFACE up
+ip link set dev $INTERFACE address $HWADDR


### PR DESCRIPTION
Mirror of zephyrproject-rtos net-tools#46
Configuration files when having multiple gPTP ports.
Usage:
  net-setup.sh -c zeth0-gptp.conf -i zeth0 start
  net-setup.sh -c zeth1-gptp.conf -i zeth1 start

Signed-off-by: Jukka Rissanen <jukka.rissanen<at>linux.intel.com>
